### PR TITLE
Alternative geoip lookup service

### DIFF
--- a/flow-typed/node-fetch.js
+++ b/flow-typed/node-fetch.js
@@ -1,0 +1,11 @@
+/* @flow */
+
+/*
+ * Flow doesn't play well with `node-fetch's` module export so we need to declare
+ * it explicitly.
+ *
+ * See: https://github.com/facebook/flow/issues/2092
+ */
+declare module 'node-fetch' {
+  declare module.exports: any;
+}

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -31,12 +31,4 @@ export const REQUEST_METHODS: Object = {
   OPTIONS: 'OPTIONS',
 };
 
-const defaults = {
-  MIME_TYPES,
-  STATUS_CODES,
-  DEFAULT_HEADERS,
-  REQUEST_TYPES,
-  REQUEST_METHODS,
-};
-
-export default defaults;
+export const LOCAL_IP: string = '127.0.0.1';

--- a/src/legacy/logger.js
+++ b/src/legacy/logger.js
@@ -3,7 +3,7 @@
 const sqlite3 = require('sqlite3').verbose();
 const fetch = require('node-fetch');
 
-const honeyLogger = ({ request, payload, response } = {}) => {
+const honeyLogger = async ({ request, payload, response } = {}) => {
   const ipAddressRaw = request.headers['x-forwarded-for'] || request.connection.remoteAddress || request.socket.remoteAddress || (request.connection.socket ? request.connection.socket.remoteAddress : null);
   const ipAddress = ipAddressRaw.substring(ipAddressRaw.lastIndexOf(':') + 1);
 

--- a/src/legacy/logger.js
+++ b/src/legacy/logger.js
@@ -15,7 +15,7 @@ const honeyLogger = ({ request, payload, response } = {}) => {
       as: 'Local connection',
       city: 'Local connection',
       country: 'Local connection',
-      isp: 'Local connection',
+      isp: null,
       lat: 0.0,
       lon: 0.0,
     };
@@ -24,7 +24,6 @@ const honeyLogger = ({ request, payload, response } = {}) => {
         as: fetchResponse.as,
         city: fetchResponse.city,
         country: fetchResponse.country,
-        isp: fetchResponse.country,
         lat: fetchResponse.lat,
         lon: fetchResponse.lon,
       };

--- a/src/legacy/logger.js
+++ b/src/legacy/logger.js
@@ -1,33 +1,27 @@
 /* eslint-disable */
 
+/*
+ * WARNING: This code is legacy.
+ */
+
+import validateIPAddress from '../validators';
+import geoJsConnector from '../utils/geoIp';
+
 const sqlite3 = require('sqlite3').verbose();
 const fetch = require('node-fetch');
 
 const honeyLogger = async ({ request, payload, response } = {}) => {
   const ipAddressRaw = request.headers['x-forwarded-for'] || request.connection.remoteAddress || request.socket.remoteAddress || (request.connection.socket ? request.connection.socket.remoteAddress : null);
   const ipAddress = ipAddressRaw.substring(ipAddressRaw.lastIndexOf(':') + 1);
-
-  const database = new sqlite3.Database('./honeypot.db');
-
-  fetch(`http://ip-api.com/json/${ipAddress}`).then(res => res.text()).then((body) => {
-    const fetchResponse = JSON.parse(body);
-    let locationObject = {
-      as: 'Local connection',
-      city: 'Local connection',
-      country: 'Local connection',
-      isp: null,
-      lat: 0.0,
-      lon: 0.0,
-    };
-    if (!fetchResponse.message) {
-      locationObject = {
-        as: fetchResponse.as,
-        city: fetchResponse.city,
-        country: fetchResponse.country,
-        lat: fetchResponse.lat,
-        lon: fetchResponse.lon,
-      };
-    }
+  if (!validateIPAddress(ipAddress)) {
+    /*
+     * @TODO Create a better error logging util
+     */
+    throw new Error(`[${new Date().toString()}] IP address ${ipAddress} is not valid`);
+  }
+  const locationObject = await geoJsConnector(ipAddress);
+  if (locationObject && locationObject.success) {
+    const database = new sqlite3.Database('./honeypot.db');
     database
       .run(
         'CREATE TABLE IF NOT EXISTS honeypot_new (id INTEGER PRIMARY KEY AUTOINCREMENT, ip TEXT, city TEXT, country TEXT, lat INT, lon INT, network TEXT, isp TEXT, ua TEXT, method TEXT, request TEXT, response TEXT, date INT);',
@@ -42,7 +36,7 @@ const honeyLogger = async ({ request, payload, response } = {}) => {
           locationObject.lat,
           locationObject.lon,
           locationObject.as,
-          locationObject.isp,
+          locationObject.isp || false,
           request.headers['user-agent'] || false,
           payload.method,
           JSON.stringify(payload),
@@ -50,7 +44,7 @@ const honeyLogger = async ({ request, payload, response } = {}) => {
         ],
       );
     database.close();
-  });
+  }
 };
 
 module.exports = honeyLogger;

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -64,7 +64,7 @@ export const start = async ({
              *
              * @TODO Handle the case in which the provider runs into and error
              */
-            ganacheProvider.send(requestPayload, (responseError, providerResponse) => {
+            ganacheProvider.send(requestPayload, async (responseError, providerResponse) => {
               /*
                * Get the response from the provider so we can send it back to the requester
                */
@@ -93,7 +93,7 @@ export const start = async ({
                * @TODO Cleaner way to log requests/responses
                */
               if (logger && typeof logger === 'function') {
-                logger({
+                await logger({
                   request,
                   payload: requestPayload,
                   response: serverReponse,

--- a/src/utils/geoIp/defaults.js
+++ b/src/utils/geoIp/defaults.js
@@ -1,0 +1,15 @@
+/* @flow */
+
+export const GEOJS_ENDPOINT: string = 'https://get.geojs.io/v1/ip/geo/';
+
+export const LOCAL_GEO_OBJECT: Object = {
+  city: 'Local',
+  country: 'Local',
+  lat: '0.0',
+  lon: '0.0',
+  as: 'Local connection',
+};
+
+export const ENUMERABLE_PROP: Object = {
+  enumerable: true,
+};

--- a/src/utils/geoIp/geoJsConnector.js
+++ b/src/utils/geoIp/geoJsConnector.js
@@ -1,0 +1,61 @@
+/* @flow */
+
+/*
+ * Flow has problems with this import, even after I've added in a generic flow type
+ */
+/* $FlowFixMe */
+import fetch from 'node-fetch';
+
+import { GEOJS_ENDPOINT, LOCAL_GEO_OBJECT, ENUMERABLE_PROP } from './defaults';
+import { LOCAL_IP } from '../../defaults';
+
+const geoJsConnector = async (ipAddress: string = LOCAL_IP): Object => {
+  /*
+   * We're assuming the IP Address is correct (already validated)
+   */
+  const endpoint = `${GEOJS_ENDPOINT}${ipAddress}.json`;
+  /*
+   * This needs to be wrapped inside a try-catch block since the fetch request might fail
+   */
+  try {
+    const fetchResult = await fetch(endpoint);
+    /*
+     * Parse the JSON response into an object
+     */
+    const resultsObject = Object.assign(
+      LOCAL_GEO_OBJECT,
+      JSON.parse(await fetchResult.text()),
+      { success: true },
+    );
+    /*
+     * Normalize the prop names and values
+     */
+    const {
+      latitude,
+      longitude,
+      organization,
+      lat,
+      lon,
+      as,
+    } = resultsObject;
+    Object.defineProperties(
+      resultsObject,
+      {
+        lat: Object.assign({}, ENUMERABLE_PROP, { value: latitude || lat }),
+        lon: Object.assign({}, ENUMERABLE_PROP, { value: longitude || lon }),
+        as: Object.assign({}, ENUMERABLE_PROP, { value: organization || as }),
+      },
+    );
+    return resultsObject;
+  } catch (caughtError) {
+    /*
+     * @TODO Create a better error logging util
+     */
+    console.log(`[${new Date().toString()}] Could not fetch data from the remote endpoint: '${endpoint}'. ${caughtError.message}`);
+    return ({
+      success: false,
+    });
+  }
+};
+
+export default geoJsConnector;

--- a/src/utils/geoIp/index.js
+++ b/src/utils/geoIp/index.js
@@ -1,0 +1,3 @@
+/* @flow */
+
+export { default } from './geoJsConnector';

--- a/src/validators.js
+++ b/src/validators.js
@@ -1,0 +1,57 @@
+/* @flow */
+
+/**
+ * Very BASIC validator to check if an IP Address is in the correct format
+ *
+ * This could do more thorough checks, but as it is, it will work for our use case.
+ *
+ * @method validateIPAddress
+ *
+ * @param {string} ipAddress the ip address string to validate
+ *
+ * @return {bool} a boolean to determine if the ip address passes our tests
+ */
+const validateIPAddress = (ipAddress: string): boolean => {
+  const ipAddressBlocks: Array<string> = ipAddress.split('.');
+  const assertCorrectFormat: Array<boolean> = [];
+  /*
+   * Should have more than one block, and at most four blocks
+   */
+  assertCorrectFormat.push(ipAddressBlocks.length >= 1 && ipAddressBlocks.length <= 4);
+  /*
+   * First block should be composed only of digits, up to a max of 3 and cannot start with 0
+   */
+  assertCorrectFormat
+    .push(/^[1-9]{1,3}$/.test(ipAddressBlocks[0]) && ipAddressBlocks[0].length <= 3);
+  /*
+   * Second and third block should be only digits, up to a max of 3 (and can start with 0, or just be 0)
+   */
+  /*
+   * We could only have one block
+   */
+  if (ipAddressBlocks.length > 1) {
+    assertCorrectFormat
+      .push(/^\d{1,3}$/.test(ipAddressBlocks[1]) && ipAddressBlocks[1].length <= 3);
+  }
+  /*
+   * We could only have two blocks
+   */
+  if (ipAddressBlocks.length > 2) {
+    assertCorrectFormat
+      .push(/^\d{1,3}$/.test(ipAddressBlocks[2]) && ipAddressBlocks[2].length <= 3);
+  }
+  /*
+   * Last block should be just as the first one, composed only of digits, up to a
+   * max of 3 and cannot start with 0
+   */
+  /*
+   * We could only have three blocks
+   */
+  if (ipAddressBlocks.length > 3) {
+    assertCorrectFormat
+      .push(/^[1-9]{1,3}$/.test(ipAddressBlocks[3]) && ipAddressBlocks[3].length <= 3);
+  }
+  return assertCorrectFormat.every(blockCorrectness => blockCorrectness === true);
+};
+
+export default validateIPAddress;


### PR DESCRIPTION
This comes as a replacement for the `ip-api` endpoint and replaces it with `geojs`.

It also cleans up the code and and makes it more modules 

Resolves #22 