### PR TITLE
Sqlite3 to Firestore migration script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "start": "node lib/index.js",
     "start:log": "node lib/index.js >> ./server.log &",
     "lint": "eslint --fix src/**/*.js",
-    "typecheck": "flow check"
+    "typecheck": "flow check",
+    "migrate:sqlite3": "yarn build && node scripts/sqlite3-migration.js"
   },
   "repository": {
     "type": "git",
@@ -49,6 +50,8 @@
     "flow": "^0.2.3",
     "flow-bin": "^0.75.0",
     "husky": "^1.0.0-rc.9",
-    "lint-staged": "^7.2.0"
+    "lint-staged": "^7.2.0",
+    "sleep": "^5.1.1",
+    "sqlite3": "^4.0.1"
   }
 }

--- a/scripts/.eslintrc
+++ b/scripts/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "flowtype/require-valid-file-annotation": [0],
+    "import/no-extraneous-dependencies": [0],
+  },
+}

--- a/scripts/sqlite3-migration.js
+++ b/scripts/sqlite3-migration.js
@@ -1,0 +1,111 @@
+/*
+ * WARNING: This script requires quite a lot of memmory, as the whole sqlite3 file will be loaded
+ * into your machines memmory.
+ */
+
+const sqlite3 = require('sqlite3');
+const path = require('path');
+const { sleep } = require('sleep');
+const firestoreAdmin = require('firebase-admin');
+
+const { errorLogger } = require('../lib/utils/errorLogger');
+const { firebaseFirestoreBatch } = require('../lib/utils/firebase');
+
+const FIREBASE_DEFAULTS = require('../lib/utils/firebase/defaults');
+
+const { DB_PATH } = process.env;
+const TABLE_NAME = process.env.TABLE_NAME || 'honeypot_new';
+const COLLECTION = process.env.COLLECTION || FIREBASE_DEFAULTS.RAW_COLLECTION;
+const FIRSTORE_BATCH_LIMIT = 2;
+const SLEEP_SECS = 5;
+
+if (!DB_PATH) {
+  errorLogger(
+    'Database path was not set, or was set to a wrong location',
+    DB_PATH || 'undefined',
+  );
+}
+
+console.log(`
+  *****************************************************************************************
+  * WARNING:                                                                              *
+  * Don't run this more than one time on a single collection as your data will double and *
+  * it will VERY hard to clean that up afterwards.                                        *
+  *****************************************************************************************
+`);
+
+/*
+ * Fetch the data from the Sqlite3 database
+ */
+const sqlite3DbInstance = new sqlite3.Database(path.resolve('.', DB_PATH));
+const SELECT_QUERY = `SELECT * FROM ${TABLE_NAME} LIMIT 5`;
+
+sqlite3DbInstance.serialize(() => {
+  console.log('Starting import...');
+  /*
+   * Get the value from the database
+   */
+  sqlite3DbInstance.all(SELECT_QUERY, (error, allRows) => {
+    console.log('Selected the queried rows from the database...');
+    while (allRows.length) {
+      /*
+       * Create the array chunk
+       *
+       * In needs to be limited to under 500 since that's max we can send
+       * in one batch to Firstore Service
+       */
+      const arrayChunk = allRows.slice(0, FIRSTORE_BATCH_LIMIT);
+      allRows.splice(0, FIRSTORE_BATCH_LIMIT);
+      /*
+       * Log current id's
+       */
+      console.log(
+        'Current batch of IDs that are being send to Firestore...',
+        ...arrayChunk.map(({ id }) => id),
+      );
+      /*
+       * Create the batch
+       */
+      firebaseFirestoreBatch(arrayChunk.map(({
+        city,
+        country,
+        date,
+        lat,
+        lon,
+        ip,
+        method,
+        network,
+        request,
+        response,
+        ua,
+      }) => ({
+        collection: COLLECTION,
+        batchMethod: 'set',
+        dataObject: {
+          city,
+          country,
+          date: new Date(new Date(0).setUTCSeconds(date)),
+          geoLocation: new firestoreAdmin.firestore.GeoPoint(
+            parseFloat(lat),
+            parseFloat(lon),
+          ),
+          ipAddress: ip,
+          method,
+          network,
+          request: JSON.parse(request),
+          response: JSON.parse(response),
+          userAgent: ua,
+        },
+      })));
+      /*
+       * Sleep, so we don't hammer the Firstore service
+       */
+      sleep(SLEEP_SECS);
+      console.log('Finished processing current batch...');
+    }
+  });
+});
+
+sqlite3DbInstance.close();
+
+console.log('Import finished successfully!');

--- a/src/stats/userAgents.js
+++ b/src/stats/userAgents.js
@@ -2,9 +2,7 @@
 
 import sanitize from 'sanitize-filename';
 
-import { errorLogger } from '../utils/errorLogger';
-
-import { DOCUMENTS, UNDEFINED, UNDERSCORE } from './defaults';
+import { DOCUMENTS, UNDERSCORE } from './defaults';
 
 /**
  * Track the number of times a request used an unique user agent
@@ -15,19 +13,14 @@ import { DOCUMENTS, UNDEFINED, UNDERSCORE } from './defaults';
  */
 export const userAgentsStats = (userAgent: string): Object => {
   try {
-    if (!userAgent || typeof userAgent !== 'string') {
-      /*
-       * @TODO Move message string to `messages.json`
-       */
-      errorLogger(
-        "Stats user agent name not available, we're not counting it",
-        userAgent || UNDEFINED,
-      );
+    let safeUserAgent = 'hidden';
+    if (userAgent && typeof userAgent === 'string') {
+      safeUserAgent = userAgent;
     }
     return {
       documentId: DOCUMENTS.USER_AGENTS,
-      propName: sanitize(userAgent, { replacement: UNDERSCORE }),
-      additionalData: { name: userAgent },
+      propName: sanitize(safeUserAgent, { replacement: UNDERSCORE }),
+      additionalData: { name: safeUserAgent },
     };
   } catch (caughtError) {
     return {};

--- a/src/utils/errorLogger/errorLogger.js
+++ b/src/utils/errorLogger/errorLogger.js
@@ -24,7 +24,7 @@ export const errorLogger = (
     if (errorValue instanceof Object) {
       loggerMessage += ` Your object: ${JSON.stringify(errorValue)}.`;
     } else {
-      loggerMessage += ` Yout value: ${errorValue}.`;
+      loggerMessage += ` Your value: ${errorValue}.`;
     }
   }
   if (errorMessage) {

--- a/src/utils/firebase/firebaseFirestoreBatch.js
+++ b/src/utils/firebase/firebaseFirestoreBatch.js
@@ -60,18 +60,13 @@ export const firebaseFirestoreBatch = async (batchArray: Array<Object>): Promise
       documentId: string,
       batchMethod: string,
       dataObject: Object,
-    },
-    index: number) => {
-      if (!documentId) {
-        /*
-         * @TODO Move message string to `messages.json`
-         */
-        return errorLogger(
-          'Batch `documentId` was not set',
-          batchArray[index] || UNDEFINED,
-        );
+    }) => {
+      let batchReference: Object = getFirestoreReference({ collection });
+      if (documentId) {
+        batchReference = batchReference.doc(documentId);
+      } else {
+        batchReference = batchReference.doc();
       }
-      const batchReference = getFirestoreReference({ collection, documentId });
       return firestoreBatch[batchMethod](batchReference, dataObject);
     });
     return firestoreBatch.commit();

--- a/yarn.lock
+++ b/yarn.lock
@@ -4694,7 +4694,7 @@ mz@^2.6.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nan@2.10.0, nan@^2.0.0, nan@^2.0.8, nan@^2.2.1, nan@^2.3.3, nan@^2.9.2:
+nan@2.10.0, nan@>=2.5.1, nan@^2.0.0, nan@^2.0.8, nan@^2.2.1, nan@^2.3.3, nan@^2.9.2, nan@~2.10.0:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
 
@@ -4723,7 +4723,7 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
-needle@^2.2.0:
+needle@^2.2.0, needle@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.1.tgz#b5e325bd3aae8c2678902fa296f729455d1d3a7d"
   dependencies:
@@ -4765,6 +4765,21 @@ node-pre-gyp@^0.10.0:
     detect-libc "^1.0.2"
     mkdirp "^0.5.1"
     needle "^2.2.0"
+    nopt "^4.0.1"
+    npm-packlist "^1.1.6"
+    npmlog "^4.0.2"
+    rc "^1.2.7"
+    rimraf "^2.6.1"
+    semver "^5.3.0"
+    tar "^4"
+
+node-pre-gyp@~0.10.1:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc"
+  dependencies:
+    detect-libc "^1.0.2"
+    mkdirp "^0.5.1"
+    needle "^2.2.1"
     nopt "^4.0.1"
     npm-packlist "^1.1.6"
     npmlog "^4.0.2"
@@ -6041,6 +6056,12 @@ slash@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
 
+sleep@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/sleep/-/sleep-5.1.1.tgz#878fa1d44d08eeb0f26fb2018ef8629eb1a3ab94"
+  dependencies:
+    nan ">=2.5.1"
+
 slice-ansi@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
@@ -6160,6 +6181,13 @@ split-string@^3.0.1, split-string@^3.0.2:
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+
+sqlite3@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-4.0.1.tgz#78e815bb50d7320fd90f03f1d7c3a920010d7ce3"
+  dependencies:
+    nan "~2.10.0"
+    node-pre-gyp "~0.10.1"
 
 sshpk@^1.7.0:
   version "1.14.2"


### PR DESCRIPTION
This PR adds a migration script to move data from the initial `sqlite3` database, that this library used initially.

Resolves #26 