### PR TITLE
Script to retroactively process stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ethereum-honeypot",
   "description": "Track external parties actions run on open ethereum nodes",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "engines": {
     "node": ">=9.11.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "start:log": "node lib/index.js >> ./server.log &",
     "lint": "eslint --fix src/**/*.js",
     "typecheck": "flow check",
-    "migrate:sqlite3": "yarn build && node scripts/sqlite3-migration.js"
+    "migrate:sqlite3": "yarn build && node scripts/sqlite3-migration.js",
+    "process:retroactive-stats": "yarn build && node scripts/retroactive-stats.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ethereum-honeypot",
   "description": "Track external parties actions run on open ethereum nodes",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "engines": {
     "node": ">=9.11.0",

--- a/readme.md
+++ b/readme.md
@@ -95,7 +95,7 @@ To be able to set up the project, you'll need a _(free)_ account and to create a
 7. At this point, you'll be able to start the server without any problems.
 
 ![Firebase Service Accounts](assets/firebase_service_accounts.png)
-
+a
 ### Migrations
 
 #### `Sqlite3` to `Firestore` migration
@@ -116,6 +116,25 @@ DB_PATH='../database/old_database.sql' COLLECTION='rpc-requests-test' yarn migra
 **WARNING: Don't run this more than one time on a single collection as your data will be doubled and it will VERY hard to clean that up afterwards.**
 
 _NOTE: Depending on the size of your database, this could take quite a toll on your [daily quota](https://firebase.google.com/docs/firestore/pricing?authuser=0). Remember, you only have `20000` writes on the free plan._
+
+#### Retroactively generate stats data
+
+This is used to generate stats data for any data that was tracked prior to the stats collection implementation.
+
+Stats only count new stats when a new request is made, but not for already available data. To make sense of your old data, there is this migration: `yarn process:retroactive-stats`
+
+It takes in two environment variables trough which you can set the source `collection` name _(from where to count stats)_, and the destination stats `collection` name _(this is optional, since this defaults to `rpc-requests-stats`)_:
+- `COLLECTION`, used to set the source `firestore` collection name, defaults to `rpc-requests-raw`.
+- `STATS_COLLECTION`, optional, used to set the destination `firestore` collection name, defaults to `rpc-requests-stats`.
+
+_Example:_
+```bash
+COLLECTION='rpc-requests-raw' yarn process:retroactive-stats
+```
+
+**WARNING: Only run this on an empty stats collection, since this will overwrite it. Usually you run this migration just after updating the code to the new version (the one that includes stats). You stop the process, run the migration, re-start the process.**
+
+_NOTE: Depending on the size of your database, this could take quite a toll on your [daily reads quota](https://firebase.google.com/docs/firestore/pricing?authuser=0). Remember, you only have `50000` reads on the free plan, so if your database is large, you might run into limits._
 
 ### License
 

--- a/readme.md
+++ b/readme.md
@@ -115,7 +115,7 @@ DB_PATH='../database/old_database.sql' COLLECTION='rpc-requests-test' yarn migra
 
 **WARNING: Don't run this more than one time on a single collection as your data will be doubled and it will VERY hard to clean that up afterwards.**
 
-_NOTE: Depending on the size of your database, this could take quite a toll on your [daily quota](https://firebase.google.com/docs/firestore/pricing?authuser=0). Remember, you only have `50000` writes on the free plan._
+_NOTE: Depending on the size of your database, this could take quite a toll on your [daily quota](https://firebase.google.com/docs/firestore/pricing?authuser=0). Remember, you only have `20000` writes on the free plan._
 
 ### License
 

--- a/readme.md
+++ b/readme.md
@@ -96,6 +96,27 @@ To be able to set up the project, you'll need a _(free)_ account and to create a
 
 ![Firebase Service Accounts](assets/firebase_service_accounts.png)
 
+### Migrations
+
+#### `Sqlite3` to `Firestore` migration
+
+The initial version of this app used the `sqlite3` file engine to store requests data.
+
+If you ran the app during that period and want to move that data to the current `Firestore` engine, there's the migration script: `yarn migrate:sqlite3`.
+
+It takes in two environment variables trough which you can set the source `database` file location, and the destination `collection` name:
+- `COLLECTION`, used to set the destination `firestore` collection name, defaults to `rpc-requests-raw`.
+- `DB_PATH`, used to set the source `sqlite3` file location. If it's not set, the script will not start.
+
+_Example:_
+```bash
+DB_PATH='../database/old_database.sql' COLLECTION='rpc-requests-test' yarn migrate:sqlite3
+```
+
+**WARNING: Don't run this more than one time on a single collection as your data will be doubled and it will VERY hard to clean that up afterwards.**
+
+_NOTE: Depending on the size of your database, this could take quite a toll on your [daily quota](https://firebase.google.com/docs/firestore/pricing?authuser=0). Remember, you only have `50000` writes on the free plan._
+
 ### License
 
 This project is licensed under [MIT](./LICENSE).

--- a/scripts/retroactive-stats.js
+++ b/scripts/retroactive-stats.js
@@ -1,0 +1,193 @@
+/*
+ * WARNING: This script will most likely hit the limit of your daily quota of reads
+ */
+const sanitize = require('sanitize-filename');
+
+const { firebaseFirestoreGetData, firebaseFirestoreBatch } = require('../lib/utils/firebase');
+
+const FIREBASE_DEFAULTS = require('../lib/utils/firebase/defaults');
+const { DOCUMENTS, UNDERSCORE } = require('../lib/stats/defaults');
+const {
+  getInitialDataObject,
+  getExistingDataObject,
+  getPaddedDate,
+} = require('../lib/stats/helpers');
+
+const COLLECTION = process.env.COLLECTION || FIREBASE_DEFAULTS.RAW_COLLECTION;
+const STATS_COLLECTION = process.env.STATS_COLLECTION || FIREBASE_DEFAULTS.STATS_COLLECTION;
+const STATS_COLLECTION_REPLICA = {
+  [DOCUMENTS.COUNTRIES]: {},
+  [DOCUMENTS.CITIES]: {},
+  [DOCUMENTS.IPS]: {},
+  [DOCUMENTS.METHODS]: {},
+  [DOCUMENTS.USER_AGENTS]: {},
+  [DOCUMENTS.YEARS]: {},
+  [DOCUMENTS.MONTHS]: {},
+  [DOCUMENTS.DAYS]: {},
+};
+
+const generateReplicaData = ({
+  documentId,
+  propName,
+  additionalData,
+}) => {
+  const allStats = STATS_COLLECTION_REPLICA[documentId];
+  if (!allStats || !Object.prototype.hasOwnProperty.call(allStats, propName)) {
+    /*
+     * Either the document id does not exist, or the prop name does not exist within the document
+     *
+     * In either case we, add it new (if the document id does not exist, it will be created)
+     */
+    STATS_COLLECTION_REPLICA[documentId] = getInitialDataObject({
+      propName,
+      additionalData,
+      statsData: allStats,
+    });
+    return;
+  }
+  /*
+   * Document id exists, and the current prop name exists, so we increment it
+   */
+  STATS_COLLECTION_REPLICA[documentId] = getExistingDataObject({
+    propName,
+    additionalData,
+    statsData: allStats,
+  });
+};
+
+const generateBatchArray = array => array.map(documentName => ({
+  collection: STATS_COLLECTION,
+  documentId: documentName,
+  batchMethod: 'set',
+  dataObject: STATS_COLLECTION_REPLICA[documentName],
+}));
+
+const processStats = async () => {
+  console.log(`
+    ***********************************************************************************************
+    * WARNING:                                                                                    *
+    * You should only run this script if you don't already have the 'rpc-requests-stats'          *
+    * collection, otherwise it will be OVERWRITTEN!!!                                             *
+    ***********************************************************************************************`);
+  console.log(`
+    ***********************************************************************************************
+    * DOUBLE WARNING:                                                                             *
+    * This will most likely make your account reach it's daily reads quota.                       *
+    * Free accounts only have 50000 document reads / day.                                         *
+    ***********************************************************************************************
+  `);
+
+  console.log(`Getting requests data from the '${COLLECTION}' collection...`);
+  console.log();
+
+  const allRequests = await firebaseFirestoreGetData({
+    collection: COLLECTION,
+  });
+
+  /* eslint-disable-next-line array-callback-return */
+  allRequests.docs.map((request, index) => {
+    const {
+      country,
+      city,
+      ipAddress,
+      geoLocation,
+      method,
+      userAgent,
+      date,
+    } = request.data();
+    console.log(`Started processing ID ${index + 1} of ${allRequests.docs.length}... ${request.id}`);
+    /*
+     * Countries
+     */
+    generateReplicaData({
+      propName: country,
+      documentId: DOCUMENTS.COUNTRIES,
+    });
+    /*
+     * Cities
+     */
+    generateReplicaData({
+      propName: city,
+      documentId: DOCUMENTS.CITIES,
+      additionalData: { geoLocation },
+    });
+    /*
+     * IP Address
+     */
+    generateReplicaData({
+      propName: ipAddress,
+      documentId: DOCUMENTS.IPS,
+    });
+    /*
+     * RPC Methods
+     */
+    generateReplicaData({
+      propName: method,
+      documentId: DOCUMENTS.METHODS,
+    });
+    /*
+     * User Agents
+     */
+    let safeUserAgent = 'hidden';
+    if (userAgent && typeof userAgent === 'string') {
+      safeUserAgent = userAgent;
+    }
+    generateReplicaData({
+      propName: sanitize(safeUserAgent, { replacement: UNDERSCORE }),
+      documentId: DOCUMENTS.USER_AGENTS,
+      additionalData: { name: safeUserAgent },
+    });
+    /*
+     * Years
+     */
+    const year = date.getFullYear();
+    generateReplicaData({
+      propName: `${year}`,
+      documentId: DOCUMENTS.YEARS,
+    });
+    /*
+     * Months
+     */
+    /*
+     * Month value is a 0 based index, so we need to increment it by one
+     */
+    const month = getPaddedDate(date.getMonth() + 1);
+    generateReplicaData({
+      propName: `${year}_${month}`,
+      documentId: DOCUMENTS.MONTHS,
+    });
+    /*
+     * Days
+     */
+    const day = getPaddedDate(date.getDate());
+    generateReplicaData({
+      propName: `${year}_${month}_${day}`,
+      documentId: DOCUMENTS.DAYS,
+    });
+  });
+
+  console.log();
+  console.log('Finished collection data for the stats collection local replica...');
+  console.log();
+
+  console.log('Generating batch write instructions...');
+  console.log();
+  const batchArray = generateBatchArray([
+    DOCUMENTS.COUNTRIES,
+    DOCUMENTS.CITIES,
+    DOCUMENTS.IPS,
+    DOCUMENTS.METHODS,
+    DOCUMENTS.USER_AGENTS,
+    DOCUMENTS.YEARS,
+    DOCUMENTS.MONTHS,
+    DOCUMENTS.DAYS,
+  ]);
+
+  console.log('Batch write stats values to the Firestore...');
+  console.log();
+  firebaseFirestoreBatch(batchArray);
+
+  console.log('Stats processing finished successfully!');
+};
+
+processStats();

--- a/scripts/sqlite3-migration.js
+++ b/scripts/sqlite3-migration.js
@@ -47,6 +47,7 @@ sqlite3DbInstance.serialize(() => {
    */
   sqlite3DbInstance.all(SELECT_QUERY, (error, allRows) => {
     console.log('Selected the queried rows from the database...');
+    console.log();
     while (allRows.length) {
       /*
        * Create the array chunk
@@ -102,6 +103,7 @@ sqlite3DbInstance.serialize(() => {
        */
       sleep(SLEEP_SECS);
       console.log('Finished processing current batch...');
+      console.log();
     }
   });
 });


### PR DESCRIPTION
This PR adds a script that will crawl an existing Firestore Collection and process stats from it.

This should be run for any data collected before the stats feature were introduced _(most likely version `0.2.2`)_

Closes #31 

Rebased on `feature/29-create-firestore-stats-collection`